### PR TITLE
Use new DateAxisItem in Plot Customization example

### DIFF
--- a/examples/customPlot.py
+++ b/examples/customPlot.py
@@ -12,40 +12,6 @@ from pyqtgraph.Qt import QtCore, QtGui
 import numpy as np
 import time
 
-class DateAxis(pg.AxisItem):
-    def tickStrings(self, values, scale, spacing):
-        strns = []
-        rng = max(values)-min(values)
-        #if rng < 120:
-        #    return pg.AxisItem.tickStrings(self, values, scale, spacing)
-        if rng < 3600*24:
-            string = '%H:%M:%S'
-            label1 = '%b %d -'
-            label2 = ' %b %d, %Y'
-        elif rng >= 3600*24 and rng < 3600*24*30:
-            string = '%d'
-            label1 = '%b - '
-            label2 = '%b, %Y'
-        elif rng >= 3600*24*30 and rng < 3600*24*30*24:
-            string = '%b'
-            label1 = '%Y -'
-            label2 = ' %Y'
-        elif rng >=3600*24*30*24:
-            string = '%Y'
-            label1 = ''
-            label2 = ''
-        for x in values:
-            try:
-                strns.append(time.strftime(string, time.localtime(x)))
-            except ValueError:  ## Windows can't handle dates before 1970
-                strns.append('')
-        try:
-            label = time.strftime(label1, time.localtime(min(values)))+time.strftime(label2, time.localtime(max(values)))
-        except ValueError:
-            label = ''
-        #self.setLabel(text=label)
-        return strns
-
 class CustomViewBox(pg.ViewBox):
     def __init__(self, *args, **kwds):
         pg.ViewBox.__init__(self, *args, **kwds)
@@ -65,10 +31,10 @@ class CustomViewBox(pg.ViewBox):
 
 app = pg.mkQApp()
 
-axis = DateAxis(orientation='bottom')
+axis = pg.DateAxisItem(orientation='bottom')
 vb = CustomViewBox()
 
-pw = pg.PlotWidget(viewBox=vb, axisItems={'bottom': axis}, enableMenu=False, title="PlotItem with custom axis and ViewBox<br>Menu disabled, mouse behavior changed: left-drag to zoom, right-click to reset zoom")
+pw = pg.PlotWidget(viewBox=vb, axisItems={'bottom': axis}, enableMenu=False, title="PlotItem with DateAxisItem and custom ViewBox<br>Menu disabled, mouse behavior changed: left-drag to zoom, right-click to reset zoom")
 dates = np.arange(8) * (3600*24*356)
 pw.plot(x=dates, y=[1,6,2,4,3,5,6,8], symbol='o')
 pw.show()


### PR DESCRIPTION
Hey, thank you for the rework in the DateAxisItem PR for pyqtgraph. This makes the custom DateAxisItem in the example obsolete, but gives a great opportunity to present the DateAxisItem there. 

It can of course be discussed whether a custom axis item should be part of the examples, probably better over at your PR on the official repository.