### PR TITLE
Revisit last bug fix

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -507,21 +507,16 @@ class AxisItem(GraphicsWidget):
 
     def linkToView(self, view):
         """Link this axis to a ViewBox, causing its displayed range to match the visible range of the view."""
-        oldView = self.linkedView()
+        self.unlinkFromView()
+
         self._linkedView = weakref.ref(view)
         if self.orientation in ['right', 'left']:
-            if oldView is not None:
-                oldView.sigYRangeChanged.disconnect(self.linkedViewChanged)
             view.sigYRangeChanged.connect(self.linkedViewChanged)
         else:
-            if oldView is not None:
-                oldView.sigXRangeChanged.disconnect(self.linkedViewChanged)
             view.sigXRangeChanged.connect(self.linkedViewChanged)
-
-        if oldView is not None:
-            oldView.sigResized.disconnect(self.linkedViewChanged)
+        
         view.sigResized.connect(self.linkedViewChanged)
-    
+        
     def unlinkFromView(self):
         """Unlink this axis from a ViewBox."""
         oldView = self.linkedView()
@@ -532,9 +527,11 @@ class AxisItem(GraphicsWidget):
         else:
             if oldView is not None:
                 oldView.sigXRangeChanged.disconnect(self.linkedViewChanged)
-        
+            view.sigXRangeChanged.connect(self.linkedViewChanged)
+
         if oldView is not None:
             oldView.sigResized.disconnect(self.linkedViewChanged)
+        view.sigResized.connect(self.linkedViewChanged)
 
     def linkedViewChanged(self, view, newRange=None):
         if self.orientation in ['right', 'left']:

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -531,7 +531,6 @@ class AxisItem(GraphicsWidget):
 
         if oldView is not None:
             oldView.sigResized.disconnect(self.linkedViewChanged)
-        view.sigResized.connect(self.linkedViewChanged)
 
     def linkedViewChanged(self, view, newRange=None):
         if self.orientation in ['right', 'left']:


### PR DESCRIPTION
Hey, the last bug fix you did mainly consisted out of reintroducing code into `linkToView` that I've refactored out into `unlinkFromView`. Since the underlying issue was that I copied one line too much into the new function `unlinkFromView`, this PR reverts your last commit and just removes that single wrong line. I am sorry for any confusion caused by introducing this issue.