### PR TITLE
Revisit last bug fix

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -507,21 +507,16 @@ class AxisItem(GraphicsWidget):
 
     def linkToView(self, view):
         """Link this axis to a ViewBox, causing its displayed range to match the visible range of the view."""
-        oldView = self.linkedView()
+        self.unlinkFromView()
+
         self._linkedView = weakref.ref(view)
         if self.orientation in ['right', 'left']:
-            if oldView is not None:
-                oldView.sigYRangeChanged.disconnect(self.linkedViewChanged)
             view.sigYRangeChanged.connect(self.linkedViewChanged)
         else:
-            if oldView is not None:
-                oldView.sigXRangeChanged.disconnect(self.linkedViewChanged)
             view.sigXRangeChanged.connect(self.linkedViewChanged)
-
-        if oldView is not None:
-            oldView.sigResized.disconnect(self.linkedViewChanged)
+        
         view.sigResized.connect(self.linkedViewChanged)
-    
+        
     def unlinkFromView(self):
         """Unlink this axis from a ViewBox."""
         oldView = self.linkedView()
@@ -532,9 +527,11 @@ class AxisItem(GraphicsWidget):
         else:
             if oldView is not None:
                 oldView.sigXRangeChanged.disconnect(self.linkedViewChanged)
-        
+            view.sigXRangeChanged.connect(self.linkedViewChanged)
+
         if oldView is not None:
             oldView.sigResized.disconnect(self.linkedViewChanged)
+        view.sigResized.connect(self.linkedViewChanged)
 
     def linkedViewChanged(self, view, newRange=None):
         if self.orientation in ['right', 'left']:

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -527,11 +527,9 @@ class AxisItem(GraphicsWidget):
         else:
             if oldView is not None:
                 oldView.sigXRangeChanged.disconnect(self.linkedViewChanged)
-            view.sigXRangeChanged.connect(self.linkedViewChanged)
 
         if oldView is not None:
             oldView.sigResized.disconnect(self.linkedViewChanged)
-        view.sigResized.connect(self.linkedViewChanged)
 
     def linkedViewChanged(self, view, newRange=None):
         if self.orientation in ['right', 'left']:


### PR DESCRIPTION
The real underlying issue for the bug you fixed with your last commit was that for whatever reason, your merge with branch 'develop' introduced two lines of code from the `linkToView` function to the `unlinkFromView` function: [https://github.com/pyqtgraph/pyqtgraph/pull/1154/commits/3958dc9976471746e651a5ad4386beca97c79345](https://github.com/pyqtgraph/pyqtgraph/pull/1154/commits/3958dc9976471746e651a5ad4386beca97c79345?link_to_pr)
I have no idea why that happened, and it worries me a bit that something like that happened during  a merge.

Your fix did not only fix that, but also dropped the use of `unlinkFromView`, copying code to exist in both `linkToView` and `unlinkFromView`. For the sake of less code duplication, this Pull Request reverts that commit and only deletes these two lines that the merge commit introduced.

If you have an idea how this could happen in the first place, I'd be very curious.