### PR TITLE
DateTimeAxis: Hardcoded limit, catch ValueErrors under Linux, timestamp offset fix

### DIFF
--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -223,7 +223,7 @@ class DateAxisItem(AxisItem):
         try:
             dates = [utcfromtimestamp(v - self.utcOffset) for v in values]
         except (OverflowError, ValueError):
-            return ['%g' % ((v-self.utcOffset)//SEC_PER_YEAR) for v in values]
+            return ['%g' % ((v-self.utcOffset)//SEC_PER_YEAR + 1970) for v in values]
             
         formatStrings = []
         for x in dates:

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -22,8 +22,15 @@ if sys.platform == 'win32':
 else:
     utcfromtimestamp = datetime.utcfromtimestamp
 
+MIN_REGULAR_TIMESTAMP = (datetime(1, 1, 1) - datetime(1970,1,1)).total_seconds()
+MAX_REGULAR_TIMESTAMP = (datetime(9999, 1, 1) - datetime(1970,1,1)).total_seconds()
+SEC_PER_YEAR = 365.25*24*3600
+
 def makeMSStepper(stepSize):
     def stepper(val, n):
+        if val < MIN_REGULAR_TIMESTAMP or val > MAX_REGULAR_TIMESTAMP:
+            return np.inf
+        
         val *= 1000
         f = stepSize * 1000
         return (val // (n*f) + 1) * (n*f) / 1000.0
@@ -31,20 +38,22 @@ def makeMSStepper(stepSize):
 
 def makeSStepper(stepSize):
     def stepper(val, n):
+        if val < MIN_REGULAR_TIMESTAMP or val > MAX_REGULAR_TIMESTAMP:
+            return np.inf
+        
         return (val // (n*stepSize) + 1) * (n*stepSize)
     return stepper
 
 def makeMStepper(stepSize):
     def stepper(val, n):
+        if val < MIN_REGULAR_TIMESTAMP or val > MAX_REGULAR_TIMESTAMP:
+            return np.inf
+        
         d = utcfromtimestamp(val)
         base0m = (d.month + n*stepSize - 1)
         d = datetime(d.year + base0m // 12, base0m % 12 + 1, 1)
         return (d - datetime(1970, 1, 1)).total_seconds()
     return stepper
-
-MIN_REGULAR_TIMESTAMP = (datetime(1, 1, 1) - datetime(1970,1,1)).total_seconds()
-MAX_REGULAR_TIMESTAMP = (datetime(9999, 1, 1) - datetime(1970,1,1)).total_seconds()
-SEC_PER_YEAR = 365.25*24*3600
 
 def makeYStepper(stepSize):
     def stepper(val, n):

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -249,3 +249,15 @@ class DateAxisItem(AxisItem):
         key = next((k for k in keys if density < k), keys[-1])
         self.zoomLevel = self.zoomLevels[key]
         self.zoomLevel.utcOffset = self.utcOffset
+        
+    def linkToView(self, view):
+        super(DateAxisItem, self).linkToView(view)
+        
+        # Set default limits
+        _min = -1e12*SEC_PER_YEAR
+        _max =  1e12*SEC_PER_YEAR
+        
+        if self.orientation in ['right', 'left']:
+            view.setLimits(yMin=_min, yMax=_max)
+        else:
+            view.setLimits(xMin=_min, xMax=_max)

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -222,7 +222,7 @@ class DateAxisItem(AxisItem):
         tickSpec = next((s for s in tickSpecs if s.spacing == spacing), None)
         try:
             dates = [utcfromtimestamp(v - self.utcOffset) for v in values]
-        except OverflowError:
+        except (OverflowError, ValueError):
             return ['%g' % ((v-self.utcOffset)//SEC_PER_YEAR) for v in values]
             
         formatStrings = []

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -222,7 +222,7 @@ class DateAxisItem(AxisItem):
         tickSpec = next((s for s in tickSpecs if s.spacing == spacing), None)
         try:
             dates = [utcfromtimestamp(v - self.utcOffset) for v in values]
-        except (OverflowError, ValueError):
+        except (OverflowError, ValueError, OSError):
             return ['%g' % ((v-self.utcOffset)//SEC_PER_YEAR + 1970) for v in values]
             
         formatStrings = []


### PR DESCRIPTION
Hey, thank you for your implementation of a parser for large timescales and the logistics around that!  This PR suggests some extensions to the system:

First I add a hardcoded limit by overriding the function `linkToView` to automatically set a limit from -1e12 to 1e12 years, as you suggested over at the pyqtgraph PR.

Second, this PR also catches `ValueError`s that I observe printed to the Linux command line when zooming out before your new `OverflowError` exception comes in.

Third, this PR corrects a minor issue that the new code that takes over on `OverflowError`s did assume timestamp 0 to be year 0, which makes the x axis jump by 1970 years when zooming out.