### PR TITLE
Adapt zoom level sizes based on current font size and screen resolution

### DIFF
--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -58,9 +58,9 @@ def makeMStepper(stepSize):
 def makeYStepper(stepSize):
     def stepper(val, n):
         if val < MIN_REGULAR_TIMESTAMP or val > MAX_REGULAR_TIMESTAMP:
-            year = val // SEC_PER_YEAR
+            year = val // SEC_PER_YEAR + 1970
             next_year = (year // (n*stepSize) + 1) * (n*stepSize)
-            return next_year * SEC_PER_YEAR
+            return (next_year - 1970) * SEC_PER_YEAR
         d = utcfromtimestamp(val)
         next_year = (d.year // (n*stepSize) + 1) * (n*stepSize)
         if next_year < 1 or next_year > 9999:

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -118,7 +118,7 @@ class TickSpec:
 
 class ZoomLevel:
     """ Generates the ticks which appear in a specific zoom level """
-    def __init__(self, tickSpecs, exampleText, maximalSpacing):
+    def __init__(self, tickSpecs, exampleText):
         """
         ============= ==========================================================
         tickSpecs     a list of one or more TickSpec objects with decreasing
@@ -129,7 +129,6 @@ class ZoomLevel:
         self.tickSpecs = tickSpecs
         self.utcOffset = 0
         self.exampleText = exampleText
-        self.maximalSpacing = maximalSpacing
 
     def tickValues(self, minVal, maxVal, minSpc):
         # return tick values for this format in the range minVal, maxVal
@@ -161,29 +160,29 @@ class ZoomLevel:
 YEAR_MONTH_ZOOM_LEVEL = ZoomLevel([
     TickSpec(YEAR_SPACING, makeYStepper(1), '%Y', autoSkip=[1, 5, 10, 25]),
     TickSpec(MONTH_SPACING, makeMStepper(1), '%b')
-], "-5.00000e+06", np.inf)
+], "-5.00000e+06")
 MONTH_DAY_ZOOM_LEVEL = ZoomLevel([
     TickSpec(MONTH_SPACING, makeMStepper(1), '%b'),
     TickSpec(DAY_SPACING, makeSStepper(DAY_SPACING), '%d', autoSkip=[1, 5])
-], "MMM", 5 * 3600*24)
+], "MMM")
 DAY_HOUR_ZOOM_LEVEL = ZoomLevel([
     TickSpec(DAY_SPACING, makeSStepper(DAY_SPACING), '%a %d'),
     TickSpec(HOUR_SPACING, makeSStepper(HOUR_SPACING), '%H:%M', autoSkip=[1, 6])
-], "MMM 00", 6 * 3600)
+], "MMM 00")
 HOUR_MINUTE_ZOOM_LEVEL = ZoomLevel([
     TickSpec(DAY_SPACING, makeSStepper(DAY_SPACING), '%a %d'),
     TickSpec(MINUTE_SPACING, makeSStepper(MINUTE_SPACING), '%H:%M',
              autoSkip=[1, 5, 15])
-], "MMM 00", 15 * 60)
+], "MMM 00")
 HMS_ZOOM_LEVEL = ZoomLevel([
     TickSpec(SECOND_SPACING, makeSStepper(SECOND_SPACING), '%H:%M:%S',
              autoSkip=[1, 5, 15, 30])
-], "99:99:99", 30)
+], "99:99:99")
 MS_ZOOM_LEVEL = ZoomLevel([
     TickSpec(MINUTE_SPACING, makeSStepper(MINUTE_SPACING), '%H:%M:%S'),
     TickSpec(MS_SPACING, makeMSStepper(MS_SPACING), '%S.%f',
              autoSkip=[1, 5, 10, 25])
-], "99:99:99", 1)
+], "99:99:99")
 
 class DateAxisItem(AxisItem):
     """
@@ -213,14 +212,14 @@ class DateAxisItem(AxisItem):
         # Set the zoom level to use depending on the time density on the axis
         self.utcOffset = time.timezone
         
-        self.zoomLevels = [
-            YEAR_MONTH_ZOOM_LEVEL,
-            MONTH_DAY_ZOOM_LEVEL,
-            DAY_HOUR_ZOOM_LEVEL,
-            HOUR_MINUTE_ZOOM_LEVEL,
-            HMS_ZOOM_LEVEL,
-            MS_ZOOM_LEVEL,
-            ]
+        self.zoomLevels = {
+            np.inf:      YEAR_MONTH_ZOOM_LEVEL,
+            5 * 3600*24: MONTH_DAY_ZOOM_LEVEL,
+            6 * 3600:    DAY_HOUR_ZOOM_LEVEL,
+            15 * 60:     HOUR_MINUTE_ZOOM_LEVEL,
+            30:          HMS_ZOOM_LEVEL,
+            1:           MS_ZOOM_LEVEL,
+            }
     
     def tickStrings(self, values, scale, spacing):
         tickSpecs = self.zoomLevel.tickSpecs
@@ -250,11 +249,16 @@ class DateAxisItem(AxisItem):
 
     def setZoomLevelForDensity(self, density):
         """
-        Setting zoomLevel and maximalSpacing based on given density of seconds per pixel
+        Setting `zoomLevel` and `minSpacing` based on given density of seconds per pixel
         
         The display format is adjusted automatically depending on the current time
         density (seconds/point) on the axis. You can customize the behaviour by 
-        overriding this function.
+        overriding this function or setting a different set of zoom levels
+        than the default one. The `zoomLevels` variable is a dictionary with the
+        maximal distance of ticks in seconds which are allowed for each zoom level
+        before the axis switches to the next coarser level. To create custom
+        zoom levels, override this function and provide custom `zoomLevelWidths` and
+        `zoomLevels`.
         """
         padding = 10
         
@@ -264,9 +268,8 @@ class DateAxisItem(AxisItem):
         
         # Fallback zoom level: Years/Months
         self.zoomLevel = YEAR_MONTH_ZOOM_LEVEL
-        for zoomLevel in self.zoomLevels:
+        for maximalSpacing, zoomLevel in self.zoomLevels.items():
             size = sizeOf(zoomLevel.exampleText)
-            maximalSpacing = zoomLevel.maximalSpacing
 
             # Test if zoom level is too fine grained
             if maximalSpacing/size < density:


### PR DESCRIPTION
This is somewhat experimental. With this commit, no longer 60 px are
assumed as width for all zoom levels, but the current font and
display resolution are considered to calculate the width of ticks in
each zoom level. See the new function `updateZoomLevels` for
details.

Before calling this function, overridden functions `paint` and
`generateDrawSpecs` provide information over the current display
and font via `self.fontScaleFactor` and `self.fontMetrics`.

Could you please check how this works on high-DPI screens before merging?