### PR TITLE
Meaningful error meassage when adding axis to multiple PlotItems

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -315,11 +315,15 @@ class PlotItem(GraphicsWidget):
                 # Remove old axis
                 oldAxis = self.axes[k]['item']
                 self.layout.removeItem(oldAxis)
+                oldAxis.scene().removeItem(oldAxis)
                 oldAxis.unlinkFromView()
             
             # Create new axis
             if k in axisItems:
                 axis = axisItems[k]
+                if axis.scene() is not None:
+                    if axis != self.axes[k]["item"]:
+                        raise RuntimeError("Can't add an axis to multiple plots.")
             else:
                 axis = AxisItem(orientation=k, parent=self)
             


### PR DESCRIPTION
As @axil noted in the DateAxisItem PR at https://github.com/pyqtgraph/pyqtgraph/pull/1154#issuecomment-616214715, currently users get a segmentation fault when  trying to add an axis to multiple `PlotItem`s. This commit adds a meaningful `RuntimeError` message for that case.