### PR TITLE
DateAxisItem Fix: Also resolve time below 0.5 seconds

### DIFF
--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -282,7 +282,7 @@ class DateAxisItem(AxisItem):
         
         # Calculate minimal spacing of items on the axis
         size = sizeOf(zoomLevel.exampleText)
-        self.minSpacing = np.ceil(density*size)
+        self.minSpacing = density*size
         
     def linkToView(self, view):
         super(DateAxisItem, self).linkToView(view)


### PR DESCRIPTION
Fix for issue mentioned in https://github.com/axil/pyqtgraph/pull/8#issuecomment-617379214: If zooming in below the 0.5 second resolution, ticks would not continue. This is because the minimal spacing of ticks on the axis was rounded to an integer value.