### PR TITLE
DateTimeAxis Fix: For years slightly > 9999, stepping broke

### DIFF
--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -288,8 +288,8 @@ class DateAxisItem(AxisItem):
         super(DateAxisItem, self).linkToView(view)
         
         # Set default limits
-        _min = -1e12*SEC_PER_YEAR
-        _max =  1e12*SEC_PER_YEAR
+        _min = -1e10*SEC_PER_YEAR
+        _max =  1e10*SEC_PER_YEAR
         
         if self.orientation in ['right', 'left']:
             view.setLimits(yMin=_min, yMax=_max)

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -64,7 +64,7 @@ def makeYStepper(stepSize):
         d = utcfromtimestamp(val)
         next_year = (d.year // (n*stepSize) + 1) * (n*stepSize)
         if next_year < 1 or next_year > 9999:
-            return next_year * SEC_PER_YEAR
+            return (next_year - 1970) * SEC_PER_YEAR
         next_date = datetime(next_year, 1, 1)
         return (next_date - datetime(1970, 1, 1)).total_seconds()
     return stepper


### PR DESCRIPTION
Stepping was off by 1970 years for years < 1 and > 9999, resulting in a gap in ticks visible when zooming out:
![image](https://user-images.githubusercontent.com/31772910/79974043-e29c2200-8498-11ea-9970-88ddd7a7a61c.png)

Fixed by subtracting the usual 1970 years also in that case.

I've just stumbled across this easy solution to the issue, which is also the last one I know of.