### PR TITLE
OrderedDict, correct y axis spacing

### DIFF
--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -265,8 +265,12 @@ class DateAxisItem(AxisItem):
         padding = 10
         
         # Size in pixels a specific tick label will take
-        def sizeOf(text):
-            return self.fontMetrics.boundingRect(text).width() + padding*self.fontScaleFactor
+        if self.orientation in ['bottom', 'top']:
+            def sizeOf(text):
+                return self.fontMetrics.boundingRect(text).width() + padding*self.fontScaleFactor
+        else:
+            def sizeOf(text):
+                return self.fontMetrics.boundingRect(text).height() + padding*self.fontScaleFactor
         
         # Fallback zoom level: Years/Months
         self.zoomLevel = YEAR_MONTH_ZOOM_LEVEL

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -2,7 +2,9 @@ import sys
 import numpy as np
 import time
 from datetime import datetime, timedelta
+
 from .AxisItem import AxisItem
+from ..pgcollections import OrderedDict
 
 __all__ = ['DateAxisItem', 'ZoomLevel']
 
@@ -212,14 +214,14 @@ class DateAxisItem(AxisItem):
         # Set the zoom level to use depending on the time density on the axis
         self.utcOffset = time.timezone
         
-        self.zoomLevels = {
-            np.inf:      YEAR_MONTH_ZOOM_LEVEL,
-            5 * 3600*24: MONTH_DAY_ZOOM_LEVEL,
-            6 * 3600:    DAY_HOUR_ZOOM_LEVEL,
-            15 * 60:     HOUR_MINUTE_ZOOM_LEVEL,
-            30:          HMS_ZOOM_LEVEL,
-            1:           MS_ZOOM_LEVEL,
-            }
+        self.zoomLevels = OrderedDict([
+            (np.inf,      YEAR_MONTH_ZOOM_LEVEL),
+            (5 * 3600*24, MONTH_DAY_ZOOM_LEVEL),
+            (6 * 3600,    DAY_HOUR_ZOOM_LEVEL),
+            (15 * 60,     HOUR_MINUTE_ZOOM_LEVEL),
+            (30,          HMS_ZOOM_LEVEL),
+            (1,           MS_ZOOM_LEVEL),
+            ])
     
     def tickStrings(self, values, scale, spacing):
         tickSpecs = self.zoomLevel.tickSpecs


### PR DESCRIPTION
This PR makes `zoomLevels` an `OrderedDict`, since its order is important for the current implementation of `setZoomLevelForDensity` that is required as tick sizes are calculated on the fly with `sizeOf`.
It also makes the height of a tick label to be the relevant parameter for spacing instead of its width by introducing a different `sizeOf` function for vertical axes. This prevents the following sparse ticks:
![image](https://user-images.githubusercontent.com/31772910/80038420-eb6f1100-84f5-11ea-9165-24f5a9772ed8.png)

Now:
![image](https://user-images.githubusercontent.com/31772910/80038492-0ccffd00-84f6-11ea-8dbb-4e6fb377701e.png)

Test code (slight adaption from `examples/DateAxisItem.py`):
```python3
"""
Demonstrates the usage of DateAxisItem to display properly-formatted 
timestamps on x-axis which automatically adapt to current zoom level.

"""
import initExample ## Add path to library (just for examples; you do not need this)

import time
from datetime import datetime, timedelta

import numpy as np
import pyqtgraph as pg
from pyqtgraph.Qt import QtGui

app = QtGui.QApplication([])

# Create a plot with a date-time axis
w = pg.PlotWidget(axisItems = {'left': pg.DateAxisItem(orientation='left')})
w.showGrid(x=True, y=True)

# Plot sin(1/x^2) with timestamps in the last 100 years
now = time.time()
x = np.linspace(2*np.pi, 1000*2*np.pi, 8301)
w.plot(now-(2*np.pi/x)**2*100*np.pi*1e7, np.sin(x), symbol='o')

w.show()

## Start Qt event loop unless running in interactive mode or using pyside.
if __name__ == '__main__':
    import sys
    if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
        app.exec_()

```